### PR TITLE
support variable definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,9 +1116,8 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smartcalc"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955f9c58b10e5e4862d39eae61ed91bdb823b52072a25276cf77999645adbc5d"
+version = "1.0.5"
+source = "git+https://github.com/superhawk610/smartcalc?branch=feat/execute-session#59ab123e2dd45c4fc087aa45c907c7c620b20c35"
 dependencies = [
  "chrono",
  "chrono-tz 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 [[package]]
 name = "smartcalc"
 version = "1.0.5"
-source = "git+https://github.com/superhawk610/smartcalc?branch=feat/execute-session#59ab123e2dd45c4fc087aa45c907c7c620b20c35"
+source = "git+https://github.com/erhanbaris/smartcalc?branch=main#1b76750102c7bc45f98d205ef08b79f15aa12d86"
 dependencies = [
  "chrono",
  "chrono-tz 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ chrono-tz = "0.5.3"
 
 [dependencies.smartcalc]
 version = "1.0.5"
-git = "https://github.com/superhawk610/smartcalc"
-branch="feat/execute-session"
+git = "https://github.com/erhanbaris/smartcalc"
+branch="main"
 
 [dependencies.log]
 version = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,18 @@ colored = "2.0.0"
 linefeed = "0.6.0"
 crossbeam-channel = "0.5.1"
 parking_lot = "0.11.1"
-smartcalc = "1.0.4"
 num-format = { version = "0.4.0", features = ["with-system-locale"] }
 const_format = "0.2.19"
 localzone = "0.2.0"
-
-# disable logging so it doesn't interrupt tui
-log = { version = "0.4.14", features = ["max_level_off", "release_max_level_off"] }
 chrono = "0.4.19"
 chrono-tz = "0.5.3"
+
+[dependencies.smartcalc]
+version = "1.0.5"
+git = "https://github.com/superhawk610/smartcalc"
+branch="feat/execute-session"
+
+[dependencies.log]
+version = "0.4.14"
+# disable logging so it doesn't interrupt tui
+features = ["max_level_off", "release_max_level_off"]

--- a/src/calculate.rs
+++ b/src/calculate.rs
@@ -1,0 +1,53 @@
+use chrono::{Local, TimeZone};
+use chrono_tz::{OffsetName, Tz};
+use num_format::SystemLocale;
+use smartcalc::{Session, SmartCalc};
+use std::cell::RefCell;
+
+const LANG: &'static str = "en";
+
+pub struct Calculate {
+    app: SmartCalc,
+    session: RefCell<Session>,
+}
+
+impl Default for Calculate {
+    fn default() -> Self {
+        let timezone = match localzone::get_local_zone() {
+            Some(tz) => match tz.parse::<Tz>() {
+                Ok(tz) => {
+                    let dt = Local::today().naive_local();
+                    tz.offset_from_utc_date(&dt).abbreviation().to_string()
+                }
+                Err(_) => "UTC".to_string(),
+            },
+            None => "UTC".to_string(),
+        };
+
+        let mut app = SmartCalc::default();
+        let locale = SystemLocale::default().unwrap();
+        app.set_decimal_seperator(locale.decimal().to_string());
+        app.set_thousand_separator(locale.separator().to_string());
+        app.set_timezone(timezone).unwrap();
+
+        let mut session = Session::new();
+        session.set_language(LANG.to_string());
+        let session = RefCell::new(session);
+
+        Self { app, session }
+    }
+}
+
+impl Calculate {
+    pub fn execute(&mut self, input: &str) -> Option<String> {
+        self.session.borrow_mut().set_text(input.to_string());
+        let res = self.app.execute_session(&self.session);
+        match &res.lines[0] {
+            Some(line) => match &line.result {
+                Ok(result) => Some(result.output.clone()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use termion::event::Key;
 use termion::input::TermRead;
 
-const LANG: &'static str = "en";
-
 // TODO: display smartcalc version as well as smartcalc-tui
 // (probably want built::util::parse_versions https://docs.rs/built/latest/built/)
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -19,10 +17,12 @@ const HEADER: &'static str = formatcp!(
     VERSION
 );
 
+mod calculate;
 mod prompt;
 mod spinner;
 mod thread_loop;
 
+use calculate::Calculate;
 use prompt::Prompt;
 use spinner::Spinner;
 
@@ -51,27 +51,7 @@ pub fn spawn() -> Result<(), Box<dyn std::error::Error>> {
     {
         let ps = Arc::downgrade(&prompt.state());
         std::thread::spawn(move || {
-            use chrono::{Local, TimeZone};
-            use chrono_tz::{OffsetName, Tz};
-            use num_format::SystemLocale;
-            use smartcalc::SmartCalc;
-
-            let timezone = match localzone::get_local_zone() {
-                Some(tz) => match tz.parse::<Tz>() {
-                    Ok(tz) => {
-                        let dt = Local::today().naive_local();
-                        tz.offset_from_utc_date(&dt).abbreviation().to_string()
-                    }
-                    Err(_) => "UTC".to_string(),
-                },
-                None => "UTC".to_string(),
-            };
-
-            let mut app = SmartCalc::default();
-            let locale = SystemLocale::default().unwrap();
-            app.set_decimal_seperator(locale.decimal().to_string());
-            app.set_thousand_separator(locale.separator().to_string());
-            app.set_timezone(timezone).unwrap();
+            let mut calc = Calculate::default();
 
             loop {
                 match ps.upgrade() {
@@ -82,17 +62,12 @@ pub fn spawn() -> Result<(), Box<dyn std::error::Error>> {
                         // TODO: memoize
                         // TODO: incorporate spinner
                         // TODO: syntax highlighting
-                        // TODO: variable definition
                         let mut ps = ps.lock();
                         // drop(ps) then relock after execution?
-                        let res = app.execute(LANG, ps.input.clone());
-
-                        match &res.lines[0] {
-                            Some(line) => match &line.result {
-                                Ok(result) => ps.set_hint(&result.output),
-                                _ => ps.clear_hint(),
-                            },
-                            _ => ps.clear_hint(),
+                        if let Some(res) = calc.execute(&ps.input) {
+                            ps.set_hint(&res);
+                        } else {
+                            ps.clear_hint();
                         }
                     }
                 }


### PR DESCRIPTION
Previously, we used `Smartcalc::execute`, which initializes a new session on each call and expects to receive/run the full text of all calculations so far (including variable definitions). Instead, we now track a single persistent session (which contains all variable definitions) and pass that to `Smartcalc::execute_session`, allowing us to execute only newly added lines while maintaining existing session state.

This relies on an unpublished change to `smartcalc` (see referenced PR).