### PR TITLE
add support for syntax highlighting

### DIFF
--- a/src/calculate.rs
+++ b/src/calculate.rs
@@ -1,3 +1,4 @@
+use crate::syntax::SyntaxToken;
 use chrono::{Local, TimeZone};
 use chrono_tz::{OffsetName, Tz};
 use num_format::SystemLocale;
@@ -39,12 +40,16 @@ impl Default for Calculate {
 }
 
 impl Calculate {
-    pub fn execute(&mut self, input: &str) -> Option<String> {
+    pub fn execute(&mut self, input: &str) -> Option<(String, Vec<SyntaxToken>)> {
         self.session.borrow_mut().set_text(input.to_string());
         let res = self.app.execute_session(&self.session);
         match &res.lines[0] {
             Some(line) => match &line.result {
-                Ok(result) => Some(result.output.clone()),
+                Ok(result) => {
+                    let output = result.output.clone();
+                    let tokens = line.ui_tokens.iter().map(|token| token.into()).collect();
+                    Some((output, tokens))
+                }
                 _ => None,
             },
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ const HEADER: &'static str = formatcp!(
 mod calculate;
 mod prompt;
 mod spinner;
+mod syntax;
 mod thread_loop;
 
 use calculate::Calculate;
@@ -61,11 +62,11 @@ pub fn spawn() -> Result<(), Box<dyn std::error::Error>> {
                     Some(ps) => {
                         // TODO: memoize
                         // TODO: incorporate spinner
-                        // TODO: syntax highlighting
                         let mut ps = ps.lock();
                         // drop(ps) then relock after execution?
-                        if let Some(res) = calc.execute(&ps.input) {
+                        if let Some((res, tokens)) = calc.execute(&ps.input) {
                             ps.set_hint(&res);
+                            ps.set_syntax_tokens(tokens);
                         } else {
                             ps.clear_hint();
                         }
@@ -96,6 +97,7 @@ pub fn spawn() -> Result<(), Box<dyn std::error::Error>> {
                 // erase hint then flush
                 let hint = ps.hint.clone();
                 ps.clear_hint();
+                ps.cur_offset = 0;
                 if hint.len() > 0 {
                     print!("{} {} {}", ps, "=>".dimmed(), hint.green());
                 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -37,6 +37,11 @@ pub fn syntax_highlight(s: &str, tokens: &[SyntaxToken]) -> Vec<ColoredString> {
     let mut strs = Vec::new();
 
     for token in tokens.iter() {
+        debug_assert!(
+            index <= token.start,
+            "expected tokens to be in order and not to overlap"
+        );
+
         // there's some input not part of a token
         if index < token.start {
             strs.push((&s[index..token.start]).into());
@@ -52,4 +57,47 @@ pub fn syntax_highlight(s: &str, tokens: &[SyntaxToken]) -> Vec<ColoredString> {
     }
 
     strs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! tkn {
+        ($start:literal $end:literal $color:tt) => {
+            SyntaxToken {
+                start: $start,
+                end: $end,
+                color: Color::$color,
+            }
+        };
+    }
+
+    macro_rules! check_syntax {
+        ($input:literal with $tokens:ident => $expected:expr) => {
+            let highlights = syntax_highlight($input, &$tokens);
+            let mut output = String::with_capacity(128);
+            for h in highlights {
+                output.push_str(&format!("{}", h));
+            }
+            assert_eq!(output, $expected);
+        };
+    }
+
+    #[test]
+    fn test_syntax_highlight() {
+        let mut tokens = Vec::new();
+        check_syntax!("" with tokens => "");
+
+        // skipping whitespace
+        check_syntax!("foo bar" with tokens => "foo bar");
+        tokens.push(tkn![0 3 Cyan]);
+        check_syntax!("foo bar" with tokens => format!("{} bar", "foo".cyan()));
+        tokens.push(tkn![4 7 Red]);
+        check_syntax!("foo bar" with tokens => format!("{} {}", "foo".cyan(), "bar".red()));
+
+        // skipping text at the start
+        let tokens = vec![tkn![4 7 Red]];
+        check_syntax!("foo bar" with tokens => format!("foo {}", "bar".red()));
+    }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,55 @@
+use colored::{Color, ColoredString, Colorize};
+
+pub struct SyntaxToken {
+    pub start: usize,
+    pub end: usize,
+    pub color: Color,
+}
+
+impl From<&smartcalc::UiToken> for SyntaxToken {
+    fn from(token: &smartcalc::UiToken) -> Self {
+        Self {
+            start: token.start,
+            end: token.end,
+            color: syntax_color(&token.ui_type),
+        }
+    }
+}
+
+fn syntax_color(tt: &smartcalc::UiTokenType) -> Color {
+    use smartcalc::UiTokenType::*;
+    match tt {
+        Text => Color::White,
+        VariableDefination => Color::White,
+        VariableUse => Color::White,
+        Comment => Color::White,
+        Month => Color::White,
+        DateTime => Color::White,
+        Number => Color::Cyan,
+        Symbol1 => Color::Red,
+        Symbol2 => Color::Red,
+        Operator => Color::Yellow,
+    }
+}
+
+pub fn syntax_highlight(s: &str, tokens: &[SyntaxToken]) -> Vec<ColoredString> {
+    let mut index = 0;
+    let mut strs = Vec::new();
+
+    for token in tokens.iter() {
+        // there's some input not part of a token
+        if index < token.start {
+            strs.push((&s[index..token.start]).into());
+        }
+
+        strs.push((&s[token.start..token.end]).color(token.color));
+        index = token.end;
+    }
+
+    // check for trailing input that's not part of a token
+    if index < s.len() {
+        strs.push((&s[index..]).into());
+    }
+
+    strs
+}


### PR DESCRIPTION
This PR adds support for real-time syntax highlighting.

![syntax-highlighting](https://user-images.githubusercontent.com/18172185/157835266-f8f7d366-fa0a-43cd-9fa2-01fd7e82ac4e.gif)

This depends on work in #9, as well as an upstream change to make `smartcalc::token::ui_token::{UiToken, UiTokenType}` pub [here](https://github.com/erhanbaris/smartcalc/pull/24).